### PR TITLE
add rightAvatarStyle so fixed width can be overwridden

### DIFF
--- a/lib/List.js
+++ b/lib/List.js
@@ -16,6 +16,7 @@ export default class List extends Component {
         rightIcon: PropTypes.element,
         leftAvatar: PropTypes.element,
         rightAvatar: PropTypes.element,
+        rightAvatarStyle: PropTypes.object,
         lines: PropTypes.number,
         primaryColor: PropTypes.string,
         onPress: PropTypes.func,
@@ -35,6 +36,7 @@ export default class List extends Component {
             leftIcon,
             leftAvatar,
             rightAvatar,
+            rightAvatarStyle,
             rightIcon,
             lines,
             onPress,
@@ -94,7 +96,7 @@ export default class List extends Component {
 
                     {rightAvatar &&
                         <View
-                            style={[styles.rightAvatar, lines > 2 && {
+                            style={[rightAvatarStyle || styles.rightAvatar, lines > 2 && {
                                 paddingTop: 16,
                                 alignSelf: 'flex-start'
                             }]}


### PR DESCRIPTION
Issue: Right area of component has fixed width by default so transaction amounts were continuing to line below.
<img width="419" alt="screen shot 2016-10-26 at 10 51 20 am" src="https://cloud.githubusercontent.com/assets/7506185/19737461/cf96ddb8-9b70-11e6-9b5e-cf6efb69b8f1.png">

Fix: Pass in prop so style for right avatar area can be overridden.
<img width="430" alt="screen shot 2016-10-26 at 10 51 43 am" src="https://cloud.githubusercontent.com/assets/7506185/19737464/d2dcd892-9b70-11e6-8167-ba5ebeb2d9c2.png">

<img width="425" alt="screen shot 2016-10-26 at 10 52 35 am" src="https://cloud.githubusercontent.com/assets/7506185/19737507/f5e9482a-9b70-11e6-807c-98ef2b0977db.png">
