### PR TITLE
add height to container of secondary text element

### DIFF
--- a/lib/List.js
+++ b/lib/List.js
@@ -78,8 +78,8 @@ export default class List extends Component {
                             }
                         </View>
                         {secondaryText &&
-                            <View>
-                                <Text style={[{ height:18 }, lines > 2 && { height: 22 * (lines - 1) -4 }, styles.secondaryText]}>
+                            <View style={styles.secondaryTextContainer}>
+                                <Text style={[lines > 2 && { height: 22 * (lines - 1) -4 }, styles.secondaryText]}>
                                     {secondaryText}
                                 </Text>
                             </View>
@@ -157,6 +157,9 @@ const styles = StyleSheet.create({
         width: 56
     },
     primaryText: Object.assign({}, TYPO.paperFontSubhead, { lineHeight: 24 }),
+    secondaryTextContainer: {
+      height:18,
+    },
     secondaryText: Object.assign({}, TYPO.paperFontBody1, {
         lineHeight: 22,
         color: 'rgba(0,0,0,.54)',


### PR DESCRIPTION
Issue: Bottom of secondary text was hidden
<img width="250" alt="screen shot 2016-11-14 at 1 49 13 pm" src="https://cloud.githubusercontent.com/assets/7506185/20283058/b908d58e-aa74-11e6-95c0-60afb0aa42c3.png">

Fix
<img width="250" alt="screen shot 2016-11-14 at 1 49 48 pm" src="https://cloud.githubusercontent.com/assets/7506185/20283059/bad1224a-aa74-11e6-98a1-4a9d35ea4870.png">
